### PR TITLE
Fix openvr usage to latest

### DIFF
--- a/data/shaders/multithreading/starsphere.frag
+++ b/data/shaders/multithreading/starsphere.frag
@@ -15,7 +15,7 @@ float hash33(vec3 p3)
 {
 	p3 = fract(p3 * HASHSCALE3);
     p3 += dot(p3, p3.yxz+19.19);
-    return fract(vec3((p3.x + p3.y)*p3.z + (p3.x+p3.z)*p3.y + (p3.y+p3.z)*p3.x));
+    return fract((p3.x + p3.y)*p3.z + (p3.x+p3.z)*p3.y + (p3.y+p3.z)*p3.x);
 }
 
 vec3 starField(vec3 pos)

--- a/examples/broken/multithreading.cpp
+++ b/examples/broken/multithreading.cpp
@@ -272,6 +272,8 @@ public:
         cmdBuffer.end();
     }
 
+	void updateDrawCommandBuffer(const vk::CommandBuffer &) override {}
+
     void updateSecondaryCommandBuffer(vk::CommandBufferInheritanceInfo inheritanceInfo) {
         // Secondary command buffer for the sky sphere
         vk::CommandBufferBeginInfo commandBufferBeginInfo;

--- a/examples/windows/vr_openvr.cpp
+++ b/examples/windows/vr_openvr.cpp
@@ -47,7 +47,7 @@ public:
         // Flip y-axis since GL UV coords are backwards.
         static vr::VRTextureBounds_t leftBounds{ 0, 0, 0.5f, 1 };
         static vr::VRTextureBounds_t rightBounds{ 0.5f, 0, 1, 1 };
-        vr::Texture_t texture{ (void*)_colorBuffer, vr::API_OpenGL, vr::ColorSpace_Auto };
+        vr::Texture_t texture{ (void*)_colorBuffer, vr::TextureType_OpenGL, vr::ColorSpace_Auto };
         vrCompositor->Submit(vr::Eye_Left, &texture, &leftBounds);
         vrCompositor->Submit(vr::Eye_Right, &texture, &rightBounds);
     }
@@ -81,7 +81,7 @@ public:
 
         openvr::for_each_eye([&](vr::Hmd_Eye eye) {
             eyeOffsets[eye] = openvr::toGlm(vrSystem->GetEyeToHeadTransform(eye));
-            eyeProjections[eye] = openvr::toGlm(vrSystem->GetProjectionMatrix(eye, 0.1f, 256.0f, vr::API_OpenGL));
+            eyeProjections[eye] = openvr::toGlm(vrSystem->GetProjectionMatrix(eye, 0.1f, 256.0f));
         });
         Parent::prepare();
     }


### PR DESCRIPTION
This fixes, the openvr examples to compile.

It also fixes the multithreading example to compile, however it is still broken. 